### PR TITLE
Fix/auth loading state

### DIFF
--- a/packages/ui/src/app/index.tsx
+++ b/packages/ui/src/app/index.tsx
@@ -5,58 +5,40 @@ import { Spin } from 'antd';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { login, logout } from 'src/shared/auth';
-import { refreshTokenService } from 'src/shared/lib';
+import { initializeAuth } from 'src/shared/auth';
+import { selectAuthInitialized } from 'src/shared/auth';
+import { useAppDispatch, useAppSelector } from 'src/shared/model';
 
 import router from './router';
 import { store } from './store';
 
 const App = function () {
-  const [authInitialized, setAuthInitialized] = useState<boolean | null>(null);
+  const authInitialized = useAppSelector(selectAuthInitialized);
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
-    const initAccessToken = async function () {
-      try {
-        const refreshToken = refreshTokenService.get();
-
-        if (refreshToken == null) {
-          throw new Error('No refresh token found');
-        }
-
-        const formParams = new URLSearchParams();
-        formParams.append('grant_type', 'refresh_token');
-        formParams.append('refresh_token', refreshToken);
-        store.dispatch(login(formParams));
-        setAuthInitialized(true);
-      } catch (error) {
-        console.log('Failed to get access token:', error);
-        store.dispatch(logout());
-        setAuthInitialized(false);
-      }
-    };
-
-    initAccessToken();
+    dispatch(initializeAuth());
   }, []);
 
-  return (
-    <React.StrictMode>
-      {authInitialized == null ? (
-        <Spin
-          style={{
-            display: 'grid',
-            placeItems: 'center',
-            height: '98svh',
-            width: '100%',
-          }}
-          size="large"
-        />
-      ) : (
-        <Provider store={store}>
-          <RouterProvider router={router} />
-        </Provider>
-      )}
-    </React.StrictMode>
+  return !authInitialized ? (
+    <Spin
+      style={{
+        display: 'grid',
+        placeItems: 'center',
+        height: '100svh',
+        width: '100%',
+      }}
+      size="large"
+    />
+  ) : (
+    <RouterProvider router={router} />
   );
 };
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </React.StrictMode>,
+);

--- a/packages/ui/src/app/router.tsx
+++ b/packages/ui/src/app/router.tsx
@@ -26,8 +26,7 @@ function RootComponent() {
 const rootRoute = createRootRoute({
   component: RootComponent,
   notFoundComponent: () => {
-    const isLogin = useAppSelector(selectUserId) != null;
-    return <>{isLogin ? <Navigate to="/webapp" /> : <Navigate to="/" />}</>;
+    return <Navigate to="/" />;
   },
 });
 

--- a/packages/ui/src/shared/auth/authSlice.ts
+++ b/packages/ui/src/shared/auth/authSlice.ts
@@ -7,10 +7,12 @@ import { jwtDecode } from 'jwt-decode';
 
 export interface AuthState {
   accessToken: string | null;
+  initialized: boolean;
 }
 
 const initialState: AuthState = {
   accessToken: null,
+  initialized: false,
 };
 
 export const authSlice = createSlice({
@@ -19,6 +21,10 @@ export const authSlice = createSlice({
   reducers: {
     setAccessToken: (state, action: PayloadAction<string>) => {
       state.accessToken = action.payload;
+      state.initialized = true;
+    },
+    setAuthInitialized: (state) => {
+      state.initialized = true;
     },
     clearAccessToken: (state) => {
       state.accessToken = null;
@@ -26,7 +32,8 @@ export const authSlice = createSlice({
   },
 });
 
-export const { setAccessToken, clearAccessToken } = authSlice.actions;
+export const { setAccessToken, setAuthInitialized, clearAccessToken } =
+  authSlice.actions;
 export const authReducer = authSlice.reducer;
 
 export const selectUserId = createSelector(
@@ -40,4 +47,9 @@ export const selectUserId = createSelector(
     const decoded = jwtDecode(token);
     return decoded.sub;
   },
+);
+
+export const selectAuthInitialized = createSelector(
+  (state: RootState) => state.auth.initialized,
+  (initialized) => initialized,
 );

--- a/packages/ui/src/shared/auth/index.ts
+++ b/packages/ui/src/shared/auth/index.ts
@@ -1,2 +1,2 @@
-export { authReducer, selectUserId } from './authSlice';
-export { login, logout } from './thunks';
+export { authReducer, selectAuthInitialized, selectUserId } from './authSlice';
+export { initializeAuth, login, logout } from './thunks';

--- a/packages/ui/src/shared/auth/thunks.ts
+++ b/packages/ui/src/shared/auth/thunks.ts
@@ -1,18 +1,58 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { getTokens, refreshTokenService } from 'src/shared/lib';
+import {
+  AuthenticationError,
+  getTokens,
+  refreshTokenService,
+} from 'src/shared/lib';
 
-import { setAccessToken } from './authSlice';
-import { clearAccessToken } from './authSlice';
+import {
+  clearAccessToken,
+  selectAuthInitialized,
+  setAccessToken,
+  setAuthInitialized,
+} from './authSlice';
 
 export const login = createAsyncThunk(
   'auth/login',
   async (formParams: URLSearchParams, { dispatch }) => {
-    const { accessToken, refreshToken } = await getTokens(formParams);
-    refreshTokenService.set(refreshToken);
-    dispatch(setAccessToken(accessToken));
-    console.log('Successfully obtained access/refresh tokens.');
+    try {
+      const { accessToken, refreshToken } = await getTokens(formParams);
+      refreshTokenService.set(refreshToken);
+
+      dispatch(setAccessToken(accessToken));
+      console.log('Successfully obtained access/refresh tokens.');
+    } catch (error) {
+      if (error instanceof AuthenticationError) {
+        console.log('Failed to obtain access/refresh token:', error);
+        dispatch(setAuthInitialized());
+      } else {
+        throw error;
+      }
+    }
   },
 );
+
+export const initializeAuth = createAsyncThunk<
+  void,
+  void,
+  { state: RootState }
+>('auth/initialize', async (_, { dispatch, getState }) => {
+  const isAuthInitialized = selectAuthInitialized(getState());
+  if (isAuthInitialized) {
+    return;
+  }
+
+  const refreshToken = refreshTokenService.get();
+  if (refreshToken == null) {
+    dispatch(setAuthInitialized());
+    return;
+  }
+
+  const formParams = new URLSearchParams();
+  formParams.append('grant_type', 'refresh_token');
+  formParams.append('refresh_token', refreshToken);
+  dispatch(login(formParams));
+});
 
 export const logout = createAsyncThunk(
   'auth/logout',


### PR DESCRIPTION
## 설명

Auth 초기화(페이지 첫 로드시 Refresh Token으로 Access Token을 발급하는 과정을 말함) 전에 라우팅 페이지가 렌더링되지 않도록 합니다.

이를 해결하기 위해 auth 초기화 여부를 Redux에서 관리하고, Redux AsyncThunk를 작성하여 이를 다룹니다.

초기화가 완료되기 전까지는 로딩 화면을 보여주도록 합니다.

## 동기 및 맥락

기존에도 초기화되기 전에 로딩 화면을 보여주도록 설계하였으나, Redux에 대한 이해 부족으로 제대로 작성하지 못했습니다.

기존에는 아직 초기화가 되지 않은 상태임에도 라우팅 페이지가 로드되었습니다. 이로 인해 예로 다음과 같은 이슈가 발생했습니다.

- 유저가 `/webapp`에 액세스함
  - 이때 비동기로 refresh Token 을 이용해서 access Token 요청
- (인증 상태 업데이트 전) access Token 부재로 로그인이 안 된 것으로 판단, `/login`으로 리다이렉트됨
- (인증 상태 업데이트 후) 다시 `/webapp`으로 리다이렉트됨

이는 짧은 시간 내 여러 번 경로 전환이 발생해 유저 입장에서 혼란을 불러일으킵니다.

이 PR에서는 이를 해결합니다. 예를 들어 `/webapp`에 액세스하면 Refresh token으로 Access token을 발급할 때까지 기다린 후 페이지가 로드됩니다. 만일 Access token 발급에 실패하면 이전처럼 `/login`으로 리다이렉트됩니다.

## 테스트 방법

브라우저를 이용한 동작 테스트

## 변경 유형

- [x] 버그 수정 (기존 기능에 영향을 주지 않는 수정)
- [ ] 새로운 기능 (기존 기능에 영향을 주지 않는 기능 추가)
- [ ] 주요 변경 (기존 기능이 예상대로 작동하지 않게 되는 수정이나 기능)

## 체크리스트

- [ ] 내 변경사항을 커버하는 테스트를 추가했습니다.
- [x] 모든 새로운 테스트와 기존 테스트가 통과했습니다.
