### PR TITLE
fix(ui): catch login failure error and show alert to user

### DIFF
--- a/packages/ui/src/pages/auth/ui/LoginPage.tsx
+++ b/packages/ui/src/pages/auth/ui/LoginPage.tsx
@@ -1,7 +1,7 @@
+import { unwrapResult } from '@reduxjs/toolkit';
 import { Button, Form, Input, message, Typography } from 'antd';
 import { useState } from 'react';
 import { login, logout } from 'src/shared/auth';
-import { AuthenticationError } from 'src/shared/lib';
 import { useAppDispatch } from 'src/shared/model';
 
 import { FormData } from '../model/FormData';
@@ -24,12 +24,14 @@ export default function LoginPage() {
       formParams.append('username', data.email);
       formParams.append('password', data.password);
 
-      dispatch(login(formParams));
+      unwrapResult(await dispatch(login(formParams)));
     } catch (error) {
-      const msgFailedReason =
-        error instanceof AuthenticationError
-          ? error.message
-          : `An unexpected error occurred: ${error}`;
+      let msgFailedReason;
+      if (error != null && typeof error === 'object' && 'message' in error) {
+        msgFailedReason = error.message;
+      } else {
+        msgFailedReason = 'An unexpected error occurred.';
+      }
       const msg = `Failed to login. ${msgFailedReason}`;
 
       messageApi.error(msg);

--- a/packages/ui/src/shared/auth/thunks.ts
+++ b/packages/ui/src/shared/auth/thunks.ts
@@ -25,9 +25,9 @@ export const login = createAsyncThunk(
       if (error instanceof AuthenticationError) {
         console.log('Failed to obtain access/refresh token:', error);
         dispatch(setAuthInitialized());
-      } else {
-        throw error;
       }
+
+      throw error;
     }
   },
 );


### PR DESCRIPTION
## 설명

로그인 실패 시 유저에게 이를 알립니다.
<!--- 변경사항을 자세히 설명해주세요 -->

## 동기 및 맥락

[PR #21](https://github.com/hnjae/full-stack-todo/pull/21)에서 로그인 관련 로직을 전부 Redux Thunk를 이용해 처리하도록 변경했습니다.

이때 에러 처리를 적절히 업데이트하지 않아, 로그인 실패 시 유저에게 아무런 알림이 가지 않는 버그가 발생했습니다.

이 PR은 해당 버그를 수정합니다.

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 해결하고자 하는 이슈가 있다면 여기에 링크해주세요 -->

## 테스트 방법

브라우저를 이용한 동작 테스트
<!--- 변경사항을 어떻게 테스트했는지 자세히 설명해주세요 -->
<!--- 테스트 환경, 코드의 다른 부분에 미치는 영향을 확인하기 위해 -->
<!--- 실행한 테스트 등의 세부사항을 포함해주세요 -->

## 변경 유형

<!--- 코드에서 어떤 유형의 변경이 이루어졌나요? 해당되는 모든 항목에 'x'를 표시하세요: -->

- [x] 버그 수정 (기존 기능에 영향을 주지 않는 수정)
- [ ] 새로운 기능 (기존 기능에 영향을 주지 않는 기능 추가)
- [ ] 주요 변경 (기존 기능이 예상대로 작동하지 않게 되는 수정이나 기능)

## 체크리스트

<!--- 다음 항목들을 검토하고 해당되는 모든 항목에 'x'를 표시하세요 -->
<!--- 확실하지 않은 사항이 있다면 언제든 문의해주세요. 도와드리겠습니다! -->

- [ ] 내 변경사항을 커버하는 테스트를 추가했습니다.
- [x] 모든 새로운 테스트와 기존 테스트가 통과했습니다.
